### PR TITLE
feat(techs): add grayscale-color transition on hover

### DIFF
--- a/src/components/portfolio/Technology.tsx
+++ b/src/components/portfolio/Technology.tsx
@@ -89,7 +89,10 @@ export default function Technology({
         <img
           src={isLightMode && !!logo_light ? logo_light : logo}
           alt={name}
-          className="h-full w-full"
+          className={`
+            h-full w-full transition duration-300
+            not-hover:grayscale
+          `}
         />
       </a>
       {subtechs && subtechs.length > 0 && dataSubtechs ? (


### PR DESCRIPTION
Tech icons now default to grayscale; when hovering, the icons transition to full color.