### PR TITLE
fix(style): clean up layout and styling

### DIFF
--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -44,9 +44,9 @@ export default function NavBar() {
             {page.name}
           </Link>
         ) : (
-          <a key={i} className="mr-4">
+          <a key={i} className="relative">
             <p className="text-neutral-500">{page.name}</p>
-            <p className="absolute top-4 text-xs text-amber-400">
+            <p className="absolute bottom-5 text-xs text-amber-400">
               Coming soon!
             </p>
           </a>

--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -26,8 +26,8 @@ export default function NavBar() {
   return (
     <div
       className={`
-        sticky top-0 z-50 flex w-full flex-row items-end mask-b-from-white
-        mask-b-from-75% mask-alpha p-4 backdrop-blur-lg
+        sticky top-0 z-50 flex w-full flex-row items-end p-4 pb-1
+        backdrop-blur-md
       `}
     >
       <h1 className="mr-8 text-3xl font-bold">NoahGer.sh</h1>

--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -57,8 +57,14 @@ export default function NavBar() {
           id="linkedin"
           url="https://www.linkedin.com/in/NoahJGersh"
           isSmall
+          forceIconColor
         />
-        <Technology id="github" url="https://github.com/NoahJGersh" isSmall />
+        <Technology
+          id="github"
+          url="https://github.com/NoahJGersh"
+          isSmall
+          forceIconColor
+        />
       </div>
     </div>
   );

--- a/src/components/portfolio/Project.tsx
+++ b/src/components/portfolio/Project.tsx
@@ -17,14 +17,14 @@ export default function Project({
       <div
         id={id}
         className={`
-          m-1 flex max-h-[250px] w-2xl flex-row rounded-lg bg-neutral-300
+          m-1 flex h-[250px] w-2xl flex-row rounded-lg bg-neutral-300
           shadow-md/20
           dark:bg-neutral-800 dark:shadow-neutral-300
         `}
       >
         <div className="flex w-full flex-col p-4">
           <h3 className="text-xl font-bold">{name}</h3>
-          <div className="h-full overflow-y-auto">{children}</div>
+          <div className="mb-auto h-full overflow-y-auto">{children}</div>
           {tech ? (
             <div className="flex flex-row justify-center">
               {tech.map((t, i) => (

--- a/src/components/portfolio/Project.tsx
+++ b/src/components/portfolio/Project.tsx
@@ -70,7 +70,13 @@ export default function Project({
         )}
         {source ? (
           <div className="absolute top-2 right-2 h-6 w-6">
-            <Technology id={source.host} url={source.url} isSmall noMargin />
+            <Technology
+              id={source.host}
+              url={source.url}
+              isSmall
+              noMargin
+              forceIconColor
+            />
           </div>
         ) : (
           <></>

--- a/src/components/portfolio/Technology.tsx
+++ b/src/components/portfolio/Technology.tsx
@@ -21,6 +21,7 @@ export default function Technology({
   url,
   noMargin,
   isSmall,
+  forceIconColor,
 }: {
   id: string;
   parentId?: string;
@@ -28,6 +29,7 @@ export default function Technology({
   url?: string;
   noMargin?: boolean;
   isSmall?: boolean;
+  forceIconColor?: boolean; // Ignore grayscale filter?
 }) {
   // Check for light mode to use higher contrast icons
   const isLightMode = useMediaQuery("(prefers-color-scheme: light)");
@@ -73,6 +75,11 @@ export default function Technology({
   // Disable margins for small icons (they're positioned differently)
   const margins = noMargin ? "" : "m-1 mt-2 mb-2";
 
+  // Apply a grayscale filter when not hovered
+  const colorFilter = forceIconColor
+    ? ""
+    : "transition duration-300 not-hover:opacity-50 not-hover:brightness-75 not-hover:grayscale not-hover:dark:brightness-100";
+
   return (
     <div className={`
       relative
@@ -90,9 +97,8 @@ export default function Technology({
           src={isLightMode && !!logo_light ? logo_light : logo}
           alt={name}
           className={`
-            h-full w-full transition duration-300
-            not-hover:opacity-50 not-hover:brightness-75 not-hover:grayscale
-            not-hover:dark:brightness-100
+            h-full w-full
+            ${colorFilter}
           `}
         />
       </a>

--- a/src/components/portfolio/Technology.tsx
+++ b/src/components/portfolio/Technology.tsx
@@ -81,11 +81,15 @@ export default function Technology({
     : "transition duration-300 not-hover:opacity-50 not-hover:brightness-75 not-hover:grayscale not-hover:dark:brightness-100";
 
   return (
-    <div className={`
-      relative
-      ${margins}
-      ${size}
-    `} ref={techRef}>
+    <div
+      className={`
+        relative
+        ${margins}
+        ${size}
+        ${colorFilter}
+      `}
+      ref={techRef}
+    >
       <a
         href={url ?? techUrl}
         target="_blank"
@@ -96,10 +100,7 @@ export default function Technology({
         <img
           src={isLightMode && !!logo_light ? logo_light : logo}
           alt={name}
-          className={`
-            h-full w-full
-            ${colorFilter}
-          `}
+          className="h-full w-full"
         />
       </a>
       {subtechs && subtechs.length > 0 && dataSubtechs ? (

--- a/src/components/portfolio/Technology.tsx
+++ b/src/components/portfolio/Technology.tsx
@@ -91,7 +91,8 @@ export default function Technology({
           alt={name}
           className={`
             h-full w-full transition duration-300
-            not-hover:grayscale
+            not-hover:opacity-50 not-hover:brightness-75 not-hover:grayscale
+            not-hover:dark:brightness-100
           `}
         />
       </a>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
   component: Home,
@@ -16,7 +16,10 @@ function Home() {
           href="https://www.linkedin.com/in/noahjgersh"
           target="_blank"
           rel="noopener noreferrer"
-          className={`font-semibold text-cyan-700 hover:text-cyan-400`}
+          className={`
+            font-semibold text-cyan-700
+            hover:text-cyan-400
+          `}
         >
           LinkedIn
         </a>
@@ -25,7 +28,10 @@ function Home() {
           href="https://github.com/NoahJGersh"
           target="_blank"
           rel="noopener noreferrer"
-          className={`font-semibold text-cyan-700 hover:text-cyan-400`}
+          className={`
+            font-semibold text-cyan-700
+            hover:text-cyan-400
+          `}
         >
           GitHub
         </a>
@@ -34,7 +40,10 @@ function Home() {
           href="https://gitlab.com/NoahJGersh"
           target="_blank"
           rel="noopener noreferrer"
-          className={`font-semibold text-cyan-700 hover:text-cyan-400`}
+          className={`
+            font-semibold text-cyan-700
+            hover:text-cyan-400
+          `}
         >
           GitLab
         </a>
@@ -45,7 +54,10 @@ function Home() {
           href="https://www.fiverr.com/s/Egx7lm8"
           target="_blank"
           rel="noopener noreferrer"
-          className={`font-semibold text-cyan-700 hover:text-cyan-400`}
+          className={`
+            font-semibold text-cyan-700
+            hover:text-cyan-400
+          `}
         >
           Fiverr
         </a>
@@ -57,18 +69,13 @@ function Home() {
           href="https://github.com/the-metalworks/cosmere-rpg"
           target="_blank"
           rel="noopener noreferrer"
-          className={`font-semibold text-cyan-700 hover:text-cyan-400`}
+          className={`
+            font-semibold text-cyan-700
+            hover:text-cyan-400
+          `}
         >
           Cosmere RPG for Foundry VTT
         </a>
-      </p>
-      <p className="p-2">
-        <Link
-          to="/portfolio"
-          className={`font-semibold text-cyan-700 hover:text-cyan-400`}
-        >
-          Portfolio
-        </Link>
       </p>
     </div>
   );


### PR DESCRIPTION
This PR improves the layout and styling of the page in subtle, but beneficial ways. These include:

- Removing the old portfolio link from the home page
- Making portfolio projects a static height
- Adjusting the "Coming Soon!" label in the `<NavBar />` to use the correct relative positioning
- Improving monochrome icon contrast on dark and light modes
- Adding an option to disable the monochrome filter on certain tech icons (i.e. in the `<NavBar />` or source code links)
- Moving the tech color filter to the parent div so the hover rules correct apply even to the parent technology
- Reducing the `NavBar />` blur intensity, and removing the gradient falloff at the bottom 