### PR TITLE
fix(config): add wrangler dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ node_modules
 .tanstack
 build
 dist
-.output
-.amplify-hosting
+.wrangler
 
 # local utilities
+# may include secrets!!
 .env.local

--- a/.wrangler/deploy/config.json
+++ b/.wrangler/deploy/config.json
@@ -1,1 +1,0 @@
-{ "configPath": "..\\..\\dist\\server\\wrangler.json", "auxiliaryWorkers": [] }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -24,6 +24,16 @@
     },
   ],
   "env": {
+    "dev": {
+      "name": "noahger-sh-dev",
+      "r2_buckets": [
+        {
+          "binding": "STATIC_DATA",
+          "bucket_name": "noahger-sh",
+          "remote": true,
+        },
+      ],
+    },
     "staging": {
       "name": "noahger-sh-stage",
       "r2_buckets": [


### PR DESCRIPTION
This PR adds a local environment to deploy to, allowing for proper local testing. It also excludes the .wrangler artifacts, and no longer cares about .output (Nitro) or .amplify-hosting (Amplify) as wrangler/Cloudflare are now the deployment tools of choice.