### PR TITLE
feat(tech): add fontawesome support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     ]
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.1.0",
+    "@fortawesome/free-brands-svg-icons": "^7.1.0",
+    "@fortawesome/react-fontawesome": "^3.1.0",
     "@tailwindcss/vite": "^4.1.14",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-router": "^1.132.27",

--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -4,6 +4,7 @@ import type { Navigation } from "~/types/navigation";
 import { useQuery } from "@tanstack/react-query";
 import Technology from "../portfolio/Technology";
 import * as Data from "~/utils/data";
+import { faGithub, faLinkedin } from "@fortawesome/free-brands-svg-icons";
 
 const getPageData = createServerFn({ method: "GET" }).handler(
   async (): Promise<Navigation.Page[]> => {
@@ -57,12 +58,14 @@ export default function NavBar() {
           url="https://www.linkedin.com/in/NoahJGersh"
           isSmall
           forceIconColor
+          faIcon={faLinkedin}
         />
         <Technology
           id="github"
           url="https://github.com/NoahJGersh"
           isSmall
           forceIconColor
+          faIcon={faGithub}
         />
       </div>
     </div>

--- a/src/components/portfolio/Project.tsx
+++ b/src/components/portfolio/Project.tsx
@@ -76,6 +76,7 @@ export default function Project({
               isSmall
               noMargin
               forceIconColor
+              faIcon={source.fa_icon}
             />
           </div>
         ) : (

--- a/src/components/portfolio/Technology.tsx
+++ b/src/components/portfolio/Technology.tsx
@@ -4,6 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useMediaQuery } from "usehooks-ts";
 import { useHover } from "@uidotdev/usehooks";
 import * as Data from "~/utils/data";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { IconDefinition } from "@fortawesome/free-brands-svg-icons";
 
 const getTechData = createServerFn({ method: "GET" }).handler(
   async (): Promise<Portfolio.TechConfig> => {
@@ -19,6 +21,7 @@ export default function Technology({
   noMargin,
   isSmall,
   forceIconColor,
+  faIcon,
 }: {
   id: string;
   parentId?: string;
@@ -27,6 +30,7 @@ export default function Technology({
   noMargin?: boolean;
   isSmall?: boolean;
   forceIconColor?: boolean; // Ignore grayscale filter?
+  faIcon?: IconDefinition;
 }) {
   // Check for light mode to use higher contrast icons
   const isLightMode = useMediaQuery("(prefers-color-scheme: light)");
@@ -94,11 +98,23 @@ export default function Technology({
         title={name}
         className="inline-block h-full w-full"
       >
-        <img
-          src={isLightMode && !!logo_light ? logo_light : logo}
-          alt={name}
-          className="h-full w-full"
-        />
+        {faIcon ? (
+          <FontAwesomeIcon
+            icon={faIcon}
+            widthAuto
+            size="xl"
+            className={`
+              h-full w-full
+              hover:text-cyan-400
+            `}
+          />
+        ) : (
+          <img
+            src={isLightMode && !!logo_light ? logo_light : logo}
+            alt={name}
+            className="h-full w-full"
+          />
+        )}
       </a>
       {subtechs && subtechs.length > 0 && dataSubtechs ? (
         <div

--- a/src/routes/portfolio.tsx
+++ b/src/routes/portfolio.tsx
@@ -1,3 +1,4 @@
+import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { createFileRoute } from "@tanstack/react-router";
 import Project from "~/components/portfolio/Project";
 
@@ -29,6 +30,7 @@ function RouteComponent() {
         source={{
           host: "github",
           url: "https://github.com/NoahJGersh/noahger.sh",
+          fa_icon: faGithub,
         }}
       >
         I built this website using TanStack. The upcoming Vastest Sea section is
@@ -88,6 +90,7 @@ function RouteComponent() {
         source={{
           host: "github",
           url: "https://github.com/the-metalworks/cosmere-rpg",
+          fa_icon: faGithub,
         }}
       >
         I am an open source contributor to the design, implementation, and

--- a/src/types/portfolio.d.ts
+++ b/src/types/portfolio.d.ts
@@ -1,3 +1,5 @@
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+
 export namespace Portfolio {
   export type TechConfig = Record<string, Technology>;
 
@@ -12,6 +14,7 @@ export namespace Portfolio {
   interface ProjectSource {
     host: name; // Should be a Technology name
     url: string;
+    fa_icon: IconDefinition;
   }
 
   export interface ProjectProps {

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,6 +677,30 @@
     "@eslint/core" "^0.16.0"
     levn "^0.4.1"
 
+"@fortawesome/fontawesome-common-types@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz#a4e0b7e40073d5fdef41182da1bc216a05875659"
+  integrity sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==
+
+"@fortawesome/fontawesome-svg-core@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz#b0a45363a4e95ec985130393c0b1b95717ef0760"
+  integrity sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.1.0"
+
+"@fortawesome/free-brands-svg-icons@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.1.0.tgz#68e08b05a99566782cff8e5a62b1cb69bdec2d35"
+  integrity sha512-9byUd9bgNfthsZAjBl6GxOu1VPHgBuRUP9juI7ZoM98h8xNPTCTagfwUFyYscdZq4Hr7gD1azMfM9s5tIWKZZA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "7.1.0"
+
+"@fortawesome/react-fontawesome@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-3.1.0.tgz#bb22f49622574a80ee74213ad8c68107f3f47e64"
+  integrity sha512-5OUQH9aDH/xHJwnpD4J7oEdGvFGJgYnGe0UebaPIdMW9UxYC/f5jv2VjVEgnikdJN0HL8yQxp9Nq+7gqGZpIIA==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"


### PR DESCRIPTION
Adds fontawesome support for navbar icons and project source icons, while also paving the way for additional fontawesome uses beyond the brand icons.